### PR TITLE
Remove SERPER key defaults and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
-# deepseekAPI
-Deepseek api
+# DeepSeek API Notebook
+
+本仓库包含一个演示如何在 Python 笔记本中调用 DeepSeek API 的示例。除了基础的对话功能外，还可选地结合 Serper 搜索服务，通过联网检索增强模型回答。
+
+## 功能特点
+- 通过命令行循环与 DeepSeek 模型对话，支持清除上下文和退出指令。
+- 可配置的联网搜索能力：在提供 `SERPER_API_KEY` 的前提下，先根据用户查询调用 Serper 搜索，再将整理后的结果交给 DeepSeek。
+- 对错误情况（如缺少密钥、搜索词为空等）进行了友好的提示。
+
+## 环境准备
+1. 安装依赖：
+   ```bash
+   pip install openai requests beautifulsoup4
+   ```
+2. 申请所需密钥：
+   - `DEEPSEEK_API_KEY`：访问 [DeepSeek](https://platform.deepseek.com/) 获取。
+   - `SERPER_API_KEY`（可选）：访问 [Serper](https://serper.dev/) 获取，用于启用联网搜索。
+
+## 配置密钥
+为避免在代码中硬编码敏感信息，请通过环境变量等安全方式提供密钥。例如在 Linux 或 macOS 终端中：
+
+```bash
+export DEEPSEEK_API_KEY="你的_deepseek_api_key"
+export SERPER_API_KEY="你的_serper_api_key"  # 若不需要搜索，可省略
+```
+
+在 Windows PowerShell 中：
+
+```powershell
+setx DEEPSEEK_API_KEY "你的_deepseek_api_key"
+setx SERPER_API_KEY "你的_serper_api_key"  # 若不需要搜索，可省略
+```
+
+配置完成后重新打开终端或 IDE，即可在笔记本中读取环境变量。
+
+## 运行示例
+1. 打开 `deepseek.ipynb`。
+2. 按顺序执行所有单元格。
+3. 在终端交互界面中输入提问即可开始对话：
+   - 输入 `退出` 结束程序。
+   - 输入 `清除` 重置历史对话。
+
+如未设置 `SERPER_API_KEY`，搜索功能会自动禁用，仍可进行普通对话。
+
+## 注意事项
+- 请妥善保管 API 密钥，不要提交到版本控制或公开仓库。
+- 运行前请确认网络访问 DeepSeek 与 Serper 的相关域名。
+- 如果需要在不同项目中重复使用，可将密钥配置在系统级环境变量或使用更安全的密钥管理工具。

--- a/deepseek.ipynb
+++ b/deepseek.ipynb
@@ -32,8 +32,8 @@
    "source": [
     "## 使用说明\n",
     "1. 首次运行前，请确保已经安装 `openai`、`requests`、`beautifulsoup4` 等依赖。\n",
-    "2. 请在运行前将下方代码中的 `YOUR_DEEPSEEK_API_KEY` 和 `YOUR_SERPER_API_KEY` 替换为真实密钥，或在环境变量中设置 `DEEPSEEK_API_KEY` 与 `SERPER_API_KEY`。\n",
-    "3. 如果不需要联网搜索，可以跳过 `SERPER_API_KEY` 的配置。\n",
+    "2. 请在运行前将 `DEEPSEEK_API_KEY` 设置为有效的 DeepSeek API 密钥。若需启用联网搜索功能，请额外配置 `SERPER_API_KEY`。\n",
+    "3. 可以通过环境变量或其他安全方式提供密钥，避免将密钥写入代码。\n",
     "4. 运行最后一个单元格后，即可通过命令行与 DeepSeek 进行对话。输入 `退出` 结束对话，输入 `清除` 清除上下文。\n"
    ]
   },
@@ -65,7 +65,7 @@
     "\n",
     "BASE_URL = \"https://api.deepseek.com\"\n",
     "DEEPSEEK_API_KEY = os.getenv(\"DEEPSEEK_API_KEY\", \"YOUR_DEEPSEEK_API_KEY\")\n",
-    "SERPER_API_KEY = os.getenv(\"SERPER_API_KEY\", \"YOUR_SERPER_API_KEY\")\n",
+    "SERPER_API_KEY = os.getenv(\"SERPER_API_KEY\")\n",
     "\n",
     "\n",
     "def _require_api_key(value: str, env_name: str) -> str:\n",
@@ -104,7 +104,7 @@
     "    query = query.strip()\n",
     "    if not query:\n",
     "        return \"搜索关键词不能为空。\"\n",
-    "    if not SERPER_API_KEY or SERPER_API_KEY.startswith(\"YOUR_\"):\n",
+    "    if not SERPER_API_KEY:\n",
     "        return \"搜索功能未启用：请先配置 SERPER_API_KEY。\"\n",
     "\n",
     "    payload = {\"q\": query, \"num\": num_results}\n",


### PR DESCRIPTION
## Summary
- remove the hardcoded Serper API key placeholder so the notebook only reads the value from the environment
- update the usage instructions in the notebook to reflect the new configuration guidance
- rewrite the README with detailed setup, configuration, and usage steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ddf440fed4832e937a602f8501ee2e