### PR TITLE
docs: expand project overview in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,121 @@
-# DeepSeek CLI 助手（Jupyter Notebook 版）
+# DeepSeek CLI 助手项目说明
 
-本仓库提供的 `deepseek.ipynb` Notebook 会在本地终端中启动一个具备提示词润色、流式输出和可选联网搜索的 DeepSeek 命令行助手。运行完成后即可在命令行持续对话，方便快速验证 DeepSeek API 的能力，或作为自定义智能助手的基础脚手架。
+本仓库提供一个基于 **DeepSeek API** 的命令行智能助手，完整逻辑封装在 `deepseek.ipynb` Notebook 中。Notebook 既可在 Jupyter/Colab 中逐单元格运行，也可直接转换为脚本，在本地终端体验带有提示词优化、结构化提示输出以及可选联网搜索的对话流程。
 
-## 功能亮点
-- **一键启动的命令行助手**：Notebook 末尾执行 `run_cli_assistant()`，即可在终端进入连续对话循环，支持上下文记忆与基础控制指令（退出、清除、继续）。
-- **提示词智能润色与结构化包装**：`PromptOptimizer` 会在发送请求前调用 DeepSeek 优化用户输入，并生成可复用的结构化提示词、评分与改进建议。
-- **流式输出体验**：`print_streaming` 以打字机效果呈现回答，提升阅读体验。
-- **可选联网搜索增强**：在输入中使用 `搜索: 关键词` 触发 Serper API，抓取网页正文并合并进提问上下文。
-- **健壮的错误处理**：Notebook 覆盖了缺失密钥、无效输入、网络异常和不安全链接等场景，确保 CLI 在真实环境中的可靠性。
+> **提示**：仓库包含 `tests/test_prompt_optimizer.py`，在本地或 CI 环境运行 `pytest` 可验证 Notebook 中的核心逻辑不会因重构而回归。
 
-## Notebook 结构速览
-- **环境初始化**：检查 `DEEPSEEK_API_KEY`，创建指向 `https://api.deepseek.com` 的 `OpenAI` 客户端，并按需读取 `SERPER_API_KEY`。
-- **工具函数**：包括流式打印、HTTP 抓取、HTML 文本提取、防止内网地址访问等逻辑。
-- **PromptOptimizer 组件**：负责提示词去重缓存、调用模型润色、结构化包装、质量评估以及“最近一次可复用提示词”的状态管理。
-- **联网搜索流程**：`search_web` 调用 Serper API，`get_webpage_content` 抓取正文并过滤不可信链接；主循环会将搜索结果拼接成新的查询。
-- **主循环 `run_cli_assistant`**：处理用户输入、触发提示词优化、允许人工编辑结构化提示词并调用 DeepSeek 获取流式回复。
+---
 
-如需查看实现细节，可直接在 Notebook 中打开相应代码单元。
+## 功能概览
+
+- **命令行对话循环**：执行 Notebook 最后一段代码后会启动 `run_cli_assistant()`，支持持续多轮对话，并内置 `退出`、`清除`、`继续` 等控制指令。对话历史会作为上下文自动保留。
+- **提示词润色与结构化包装**：`PromptOptimizer` 会在发送给模型前对用户输入进行优化，生成带有角色、背景、输出要求的结构化提示词，同时返回评分、改进建议及逻辑链条，方便复用与人工审阅。
+- **可选联网搜索增强**：输入以 `搜索:` 或 `搜索：` 开头的问题时会调用 `search_web()` 访问 Serper API，并借助 `get_webpage_content()` 抓取网页正文后整合进提问上下文。所有 URL 会经过 `_is_safe_url()` 校验，避免访问内网或环回地址。
+- **流式输出体验**：`get_ai_streaming_response()` 以流式方式打印模型回答，同时保留完整文本，用于追加到会话历史。
+- **健壮的错误处理**：针对缺失密钥、空输入、请求异常、结构化提示词过短或过长等场景都提供了提示或降级路径，确保 CLI 在真实环境中更加可靠。
+
+---
+
+## 仓库结构
+
+```
+.
+├── README.md               项目说明（当前文件）
+├── deepseek.ipynb          Notebook 版 DeepSeek CLI 助手
+└── tests
+    └── test_prompt_optimizer.py  覆盖核心逻辑的单元测试
+```
+
+### Notebook 代码组织
+
+1. **环境准备**：导入依赖、读取 `DEEPSEEK_API_KEY`、构建指向 `https://api.deepseek.com` 的 `OpenAI` 客户端，并在缺少密钥时抛出清晰提示。
+2. **工具与数据结构**：包括打字机式输出的 `print_streaming()`、保存优化结果的 `OptimizedPrompt` 数据类，以及结构化提示模板常量。
+3. **PromptOptimizer 组件**：
+   - 去重缓存与复用 (`_cache`、`reuse_last()`、`mark_used()`)
+   - 调用 DeepSeek 优化原始提示词 (`_call_model()`)
+   - 生成结构化模板、评分、反馈与逻辑链条 (`build_structured_prompt()`、`review_prompt()`、`build_logic_flow()`)
+   - 确保从缓存读出的对象是深拷贝，避免后续编辑污染缓存。
+4. **联网搜索与网页抓取**：通过 Serper 搜索接口获取结果，合并网页正文，并限制最大重定向次数与可访问域。
+5. **CLI 主流程**：处理用户输入、触发提示词优化、允许人工编辑结构化提示词、复用最近一次确认的提示词，并以流式方式展示回答。
+
+### 测试覆盖重点
+
+`tests/test_prompt_optimizer.py` 通过加载 Notebook 并注入 Stub 模块来模拟离线执行环境，重点校验以下行为：
+
+- **缓存独立性**：手工编辑返回对象不会污染缓存结果，再次调用 `optimize()` 会得到新的独立实例。
+- **复用提示词需显式确认**：只有通过 `mark_used()` 标记的 payload 才会被 `reuse_last()` 复用，防止误复用。
+- **搜索提示语句包含特定中文引导**，确保 CLI 文案稳定。
+- **不安全 URL 会被拒绝访问**，包括 `ftp://` 与 `127.0.0.1`。
+
+---
 
 ## 环境准备
-1. **安装依赖**（初次运行时，可在 Notebook 顶部取消注释 `%pip install ...`，或在终端手动执行）：
+
+1. **安装依赖**（可在 Notebook 顶部取消注释 `%pip install ...`，或直接在终端执行）：
    ```bash
    pip install openai requests beautifulsoup4
    ```
 2. **配置环境变量**：
-   - `DEEPSEEK_API_KEY`（必填）：前往 [DeepSeek 平台](https://platform.deepseek.com/) 申请。
-   - `SERPER_API_KEY`（可选）：前往 [Serper](https://serper.dev/) 获取，启用搜索能力。
+   - `DEEPSEEK_API_KEY`（必填）：从 [DeepSeek 平台](https://platform.deepseek.com/) 获取，用于调用 `deepseek-chat` 模型。
+   - `SERPER_API_KEY`（可选）：从 [Serper](https://serper.dev/) 获取，用于启用联网搜索。
 
 ### 环境变量示例
+
 ```bash
 # Linux / macOS
 export DEEPSEEK_API_KEY="你的_deepseek_api_key"
-export SERPER_API_KEY="你的_serper_api_key"  # 不使用搜索时可忽略
+export SERPER_API_KEY="你的_serper_api_key"  # 不使用搜索时可省略
 ```
 
 ```powershell
 # Windows PowerShell
 setx DEEPSEEK_API_KEY "你的_deepseek_api_key"
-setx SERPER_API_KEY "你的_serper_api_key"  # 不使用搜索时可忽略
+setx SERPER_API_KEY "你的_serper_api_key"  # 不使用搜索时可省略
 ```
 
-重新打开终端或 IDE 后，Notebook 即可读取上述配置。
+重新打开终端或 IDE 后，Notebook 即可读取以上配置。
 
-## 使用流程
-1. 打开 `deepseek.ipynb`，按顺序运行所有单元格（或使用 “Run All”）。
-2. 终端提示 `用户:` 时即可输入问题开始对话。
-3. 输入 `搜索: 关键词`（冒号支持半角或全角）即可触发联网搜索；若未配置 `SERPER_API_KEY` 会自动跳过并继续使用原始问题。
-4. 输入 `清除` 重置对话上下文；输入 `继续` 复用最近一次确认过的结构化提示词；输入 `退出` 结束对话。
-5. 在提示词优化阶段可选择使用、放弃或手动编辑结构化提示词，CLI 会根据选择继续对话或返回等待新问题。
+---
 
-## 测试与开发
-- 运行单元测试，确保 Notebook 中的关键逻辑保持稳定：
+## 运行方式
+
+1. 打开 `deepseek.ipynb` 并依次执行所有单元格（或选择 “Run All”）。
+2. 命令行提示 `用户:` 时输入问题即可开始对话。
+3. 在输入中使用 `搜索: 关键词`（支持全角/半角冒号）即可触发联网搜索；若未设置 `SERPER_API_KEY`，CLI 会提示搜索不可用并继续使用原始问题。
+4. 在提示词优化阶段，按照提示选择：
+   - `y` / 回车：直接使用模型生成的结构化提示词；
+   - `n`：放弃本次结果，返回输入阶段；
+   - `e`：手动编辑结构化提示词，输入完成后以单独一行 `END` 结束，CLI 会重新评分并生成新的逻辑链条。
+5. 随时输入 `清除` 重置对话历史，或输入 `继续` 复用最近一次已确认的结构化提示词。
+6. 输入 `退出` 结束对话循环。
+
+如需在纯 Python 环境下运行，可将 Notebook 转换为脚本（例如使用 `nbconvert` 或上述 `deepseek.py` 示例），并在脚本末尾调用 `run_cli_assistant()`。
+
+---
+
+## 开发与测试
+
+- **运行单元测试**：
   ```bash
   pytest
   ```
-- Notebook 中的网络调用在测试环境会被替换为本地 Stub，以便离线运行。实际使用时请确保网络可用并已配置所需密钥。
+  测试会加载 Notebook、注入离线 Stub 模块，并验证提示词优化缓存、搜索提示语句、URL 安全策略等关键逻辑。
 
-## 常见问题
-- **未配置搜索密钥**：未设置 `SERPER_API_KEY` 时，联网搜索会被跳过，助手仍可正常对话。
-- **网络或 API 异常**：CLI 会输出详细的错误提示，请根据提示检查网络、代理或密钥是否正确。
-- **安全性**：`get_webpage_content` 会拒绝内网、环回等不安全链接，避免抓取潜在危险资源。
+- **断网或无密钥情况下的体验**：
+  - `_require_api_key()` 会在缺失 `DEEPSEEK_API_KEY` 时抛出清晰异常，提醒用户提前配置。
+  - 测试环境通过 Stub 保证 `openai`、`requests`、`bs4` 模块可用，即使在无网络的 CI 环境也能完成测试。
 
-祝使用顺利，欢迎基于此 Notebook 拓展自己的 DeepSeek CLI 助手！
+- **扩展思路**：如需自定义输出格式、增加多轮搜索或接入其他 API，可在 `PromptOptimizer` 和 `run_cli_assistant()` 的交互逻辑基础上继续扩展。
+
+---
+
+## 常见问题解答
+
+| 问题 | 解决方案 |
+| --- | --- |
+| 提示缺少 `DEEPSEEK_API_KEY` | 检查环境变量是否正确设置，或直接在 Notebook 中替换占位符。 |
+| 搜索功能不可用 | 未设置 `SERPER_API_KEY` 时会收到友好提示，仍可继续对话。 |
+| URL 抓取失败 | `_is_safe_url()` 会拒绝非 HTTP(S)、内网或环回地址；确认链接是否公开可访问。 |
+| 手动编辑后的提示词被缓存污染 | `PromptOptimizer` 会深拷贝缓存，确保再次调用 `optimize()` 时得到干净的副本。 |
+
+祝使用顺利，欢迎在此基础上构建更丰富的 DeepSeek 应用！


### PR DESCRIPTION
## Summary
- rewrite the README to better explain the CLI assistant features, structure, and setup steps
- document how the notebook is organized, what the tests cover, and how to run the workflow end to end

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68fe22503bb48320bdfe0e3b8ec63a7a